### PR TITLE
Add support for Lorem Picsum

### DIFF
--- a/Classes/Resource/Picsum/PicsumResource.php
+++ b/Classes/Resource/Picsum/PicsumResource.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IchHabRecht\Filefill\Resource\Picsum;
+
+/*
+ * This file is part of the TYPO3 extension filefill.
+ *
+ * (c) Nicole Cordes <typo3@cordes.co>
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use GuzzleHttp\Exception\RequestException;
+use IchHabRecht\Filefill\Resource\RemoteResourceInterface;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class PicsumResource implements RemoteResourceInterface
+{
+    /**
+     * @var array
+     */
+    protected $allowedFileExtensions = [
+        'jpeg',
+        'jpg',
+    ];
+
+    /**
+     * @var RequestFactory
+     */
+    protected $requestFactory;
+
+    /**
+     * @var string
+     */
+    protected $url = 'https://picsum.photos/id/%s/%s/%s.%s';
+
+    public function __construct($_, RequestFactory $requestFactory = null)
+    {
+        $this->requestFactory = $requestFactory ?: GeneralUtility::makeInstance(RequestFactory::class);
+    }
+
+    /**
+     * @param string $fileIdentifier
+     * @param string $filePath
+     * @param FileInterface|null $fileObject
+     * @return bool
+     */
+    public function hasFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    {
+        if (is_null($fileObject)) {
+            return false;
+        }
+        return $fileObject instanceof FileInterface
+            && in_array($fileObject->getExtension(), $this->allowedFileExtensions, true);
+    }
+
+    /**
+     * @param string $fileIdentifier
+     * @param string $filePath
+     * @param FileInterface|null $fileObject
+     * @return string
+     */
+    public function getFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    {
+        if (is_null($fileObject)) {
+            return false;
+        }
+        try {
+            // Generate a fixed numerical ID from 1 to 999 from the hashed identifier.
+            // Same identifier will get the same ID again.
+            // Reason: There are about 1000 different images on Lorem Picsum, see https://picsum.photos/images
+            $id = (int)preg_replace('/^.*?(\d).*?(\d).*?(\d).*?$/', '\1\2\3', $fileObject->getHashedIdentifier());
+            $width = max(1, $fileObject->getProperty('width'));
+            $height = max(1, $fileObject->getProperty('height'));
+            $fileExtension = $fileObject->getExtension();
+            $url = sprintf($this->url, $id, $width, $height, $fileExtension);
+            $response = $this->requestFactory->request($url);
+            $content = $response->getBody()->getContents();
+
+            return $content;
+        } catch (RequestException $e) {
+            return false;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,16 @@ Configuration:
 
 - no configuration required (the checkbox is just a field placeholder)
 
-There is no need for multiple usage. This resource can be the last one in the chain but can handle image files only.
+### Picsum.photos
+
+Fetch a missing image from the [Lorem Picsum](https://picsum.photos) service.
+This will reuse the same image from the pool of images of Lorem Picsum.
+
+Configuration:
+
+- no configuration required (the checkbox is just a field placeholder)
+
+This resource can be the last one in the chain but can handle image files only.
 
 ## Additional resources
 

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -27,6 +27,9 @@
             <trans-unit id="sys_file_storage.filefill.placeholder_com">
                 <source>Placeholder.com</source>
             </trans-unit>
+            <trans-unit id="sys_file_storage.filefill.picsum_photos">
+                <source>Lorem Picsum (picsum.photos)</source>
+            </trans-unit>
             <trans-unit id="sys_file_storage.filefill.no_missing">
                 <source>No missing files found!</source>
             </trans-unit>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -62,6 +62,17 @@ call_user_func(function () {
                 ],
                 'handler' => \IchHabRecht\Filefill\Resource\Placeholder\PlaceholderResource::class,
             ],
+            'picsum' => [
+                'title' => 'LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.picsum_photos',
+                'config' => [
+                    'label' => 'LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.picsum_photos',
+                    'config' => [
+                        'type' => 'check',
+                        'default' => '1',
+                    ],
+                ],
+                'handler' => \IchHabRecht\Filefill\Resource\Picsum\PicsumResource::class,
+            ],
         ],
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['resourceHandler']
     );


### PR DESCRIPTION
Will fetch some more beautiful images from [Lorem Picsum](https://picsum.photos/) instead of the boring "Placeholder" images.

Images with the same identifier will always fetch the same image again.

Configuration identifier is "picsum".